### PR TITLE
Display the entire Matlab error message on Windows.

### DIFF
--- a/src/mlab/matlabcom.py
+++ b/src/mlab/matlabcom.py
@@ -86,8 +86,7 @@ class MatlabCom(object):
     #print ret
     if identify_erros and ret.rfind('???') != -1:
       begin = ret.rfind('???') + 4
-      end = ret.find('\n', begin)
-      raise MatlabError(ret[begin:end])
+      raise MatlabError(ret[begin:])
     return ret
 
   def get(self, names_to_get, convert_to_numpy=True):


### PR DESCRIPTION
Whenever Matlab throws an error on Windows, the error message is cut off so it doesn't display a traceback.  This change makes the error display the entire Matlab traceback (so debugging is _way_ easier).